### PR TITLE
Link social icons to external profiles

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -62,10 +62,18 @@ const Footer = () => {
           </span>
 
           <div className="flex items-center gap-5 text-muted-foreground">
-            <Link href="#" target="_blank">
+            <Link
+              href="https://github.com/MatiasGalli"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <GithubLogo className="h-5 w-5" />
             </Link>
-            <Link href="#" target="_blank">
+            <Link
+              href="https://www.linkedin.com/in/matias-galli-alonzo/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <LinkedinLogo className="h-5 w-5" />
             </Link>
           </div>

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -28,15 +28,29 @@ const Navbar = () => {
             variant="outline"
             className="hidden sm:inline-flex rounded-full shadow-none"
             size="icon"
+            asChild
           >
-            <LinkedinLogo />
+            <a
+              href="https://www.linkedin.com/in/matias-galli-alonzo/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <LinkedinLogo />
+            </a>
           </Button>
           <Button
             variant="outline"
             className="rounded-full shadow-none"
             size="icon"
+            asChild
           >
-            <GithubLogo className="h-5 w-5" />
+            <a
+              href="https://github.com/MatiasGalli"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <GithubLogo className="h-5 w-5" />
+            </a>
           </Button>
 
           {/* Mobile Menu */}


### PR DESCRIPTION
## Summary
- update navbar social buttons to open the correct LinkedIn and GitHub profiles
- point footer social icons to the external LinkedIn and GitHub URLs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf3639b150832da7c45553f27df682